### PR TITLE
Remove superfluous title in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# tflite_native
-
 [![Build Status](https://travis-ci.org/dart-lang/tflite_native.svg?branch=master)](https://travis-ci.org/dart-lang/tflite_native)
 
 A Dart interface to [TensorFlow Lite (tflite)](tensorflow.org/lite) through
 Dart's [foreign function interface (FFI)](https://dart.dev/server/c-interop).
-This library wraps the experimental tflite [C
-API](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/c/c_api.h).
+This library wraps the experimental tflite
+[C API](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/c/c_api.h).


### PR DESCRIPTION
It's duplicated in all contexts we'd care about.