### PR TITLE
Include MacOS 64-bit shared object file

### DIFF
--- a/lib/src/bindings/dlib.dart
+++ b/lib/src/bindings/dlib.dart
@@ -7,7 +7,7 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate' show Isolate;
 
-const Set<String> _supported = {'linux64'};
+const Set<String> _supported = {'linux64', 'mac64'};
 
 /// Computes the shared object filename for this os and architecture.
 ///


### PR DESCRIPTION
This was created by running

`bazel build -s --config=darwin_x86_64 tensorflow/lite/experimental/c:libtensorflowlite_c.so`

on a MacBook and test by running the unit tests on the same machine.