### PR TITLE
Remove type argument from structs

### DIFF
--- a/lib/src/bindings/types.dart
+++ b/lib/src/bindings/types.dart
@@ -5,16 +5,16 @@
 import 'dart:ffi';
 
 /// Wraps a model interpreter.
-class TfLiteInterpreter extends Struct<TfLiteInterpreter> {}
+class TfLiteInterpreter extends Struct {}
 
 /// Wraps customized interpreter configuration options.
-class TfLiteInterpreterOptions extends Struct<TfLiteInterpreterOptions> {}
+class TfLiteInterpreterOptions extends Struct {}
 
 /// Wraps a loaded TensorFlowLite model.
-class TfLiteModel extends Struct<TfLiteModel> {}
+class TfLiteModel extends Struct {}
 
 /// Wraps data associated with a graph tensor.
-class TfLiteTensor extends Struct<TfLiteTensor> {}
+class TfLiteTensor extends Struct {}
 
 /// Status of a TensorFlowLite function call.
 class TfLiteStatus {


### PR DESCRIPTION
This breaks the package in Dart 2.6.0-dev6 but allows us to land https://dart-review.googlesource.com/c/sdk/+/121422 by being able to pin the git hash of this commit in the DEPS file.

N.b. If we could pull this on a branch, we do not have to break the package.