### PR TITLE
Remove dependency on the quiver package.

### DIFF
--- a/lib/src/check.dart
+++ b/lib/src/check.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2020, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Throws an [ArgumentError] if [test] is false.
+void checkArgument(bool test, {String message}) {
+  if (!test) throw ArgumentError(message);
+}
+
+/// Throws a [StateError] if [test] is false.
+void checkState(bool test, {String message}) {
+  if (!test) throw StateError(message ?? 'failed precondition');
+}

--- a/lib/src/interpreter.dart
+++ b/lib/src/interpreter.dart
@@ -5,10 +5,10 @@
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
-import 'package:quiver/check.dart';
 
 import 'bindings/interpreter.dart';
 import 'bindings/types.dart';
+import 'check.dart';
 import 'ffi/helper.dart';
 import 'interpreter_options.dart';
 import 'model.dart';

--- a/lib/src/interpreter_options.dart
+++ b/lib/src/interpreter_options.dart
@@ -4,10 +4,9 @@
 
 import 'dart:ffi';
 
-import 'package:quiver/check.dart';
-
 import 'bindings/interpreter_options.dart';
 import 'bindings/types.dart';
+import 'check.dart';
 
 /// TensorFlowLite interpreter options.
 class InterpreterOptions {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -5,10 +5,10 @@
 import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
-import 'package:quiver/check.dart';
 
 import 'bindings/model.dart';
 import 'bindings/types.dart';
+import 'check.dart';
 import 'ffi/helper.dart';
 
 /// TensorFlowLite model.

--- a/lib/src/tensor.dart
+++ b/lib/src/tensor.dart
@@ -6,10 +6,10 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:quiver/check.dart';
 
 import 'bindings/tensor.dart';
 import 'bindings/types.dart';
+import 'check.dart';
 import 'ffi/helper.dart';
 
 export 'bindings/types.dart' show TfLiteType;
@@ -19,7 +19,7 @@ class Tensor {
   final Pointer<TfLiteTensor> _tensor;
 
   Tensor(this._tensor) {
-    checkNotNull(_tensor);
+    ArgumentError.checkNotNull(_tensor);
   }
 
   /// Name of the tensor element.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 
 dependencies:
   path: ^1.6.2
-  quiver: ^2.0.3
   ffi: ^0.1.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tflite_native
-version: 0.4.0
+version: 0.4.0+1
 author: Dart Team <misc@dartlang.org>
 description: >-
   A Dart interface to TensorFlow Lite through Dart FFI. This library wraps the


### PR DESCRIPTION
This package is used by the Dart SDK,
and it's on of the few packages making the SDK depend on the quiver package.

Replacing the quiver methods with simpler local alternatives,
which supports only the functionality actually used,
both simplifies the code and the maintenance.